### PR TITLE
Update README_ja.md

### DIFF
--- a/README_ja.md
+++ b/README_ja.md
@@ -1,1 +1,31 @@
+## Embeddium(Sodium) Unofficial Translate
 
+![Embeddium Unofficial Translate](https://cdn.modrinth.com/data/cached_images/0f1213c99ad37ce9dc41b691d2bd0516f81e875b.png)
+
+# 説明📖
+An unofficial resource pack for translating [Embeddium](https://github.com/embeddedt/embeddium)([Sodium](https://github.com/CaffeineMC/sodium-fabric))
+
+# 必要なMod🔴
+[Embeddium](https://github.com/embeddedt/embeddium), [Sodium](https://github.com/CaffeineMC/sodium-fabric)([Rubidium](https://github.com/Asek3/Rubidium))
+
+# 更新頻度⌚
+気分に応じて更新します。
+ただし、何かが未完成の場合、更新することはほとんどありません。
+
+# Modとの互換性👜
+Embeddium、Sodium、Rubidium は相互に互換性がありません。いずれかをインストールする場合は、いずれかを使用してください。
+
+# ダウンロードプラットフォーム📁
+[CurseForge](https://www.curseforge.com/minecraft/texture-packs/eujt-continued/files/all?page=1&pageSize=20) | [Modrinth(Recommend)](https://modrinth.com/resourcepack/eujt-continued/versions) | [GitHub Releases(Here)](https://github.com/penpea/eujt-continued/releases)
+
+## _私の名前を知っている人がいれば..._ 🐧
+もしかしたらこのリソースパックをご存じの方、見覚えがある方もいらっしゃるかもしれません...
+はい、このリソースパックは EUJT (Embeddium Translation Resource Pack) の続編です。
+
+更新されていないバージョンは[こちら](https://github.com/penguin06329/Embeddium-Unofficial-Japanese-Translate)です
+
+## その他
+[X(Twitter)](https://x.com/penguin06329b)
+
+**Modpackに関して**: 
+この翻訳リソース パックをあなたの Modpack に自由に含めることができます。許可など必要ありません！


### PR DESCRIPTION
## Embeddium(Sodium) Unofficial Translate

![Embeddium Unofficial Translate](https://cdn.modrinth.com/data/cached_images/0f1213c99ad37ce9dc41b691d2bd0516f81e875b.png)

# 説明📖
An unofficial resource pack for translating [Embeddium](https://github.com/embeddedt/embeddium)([Sodium](https://github.com/CaffeineMC/sodium-fabric))

# 必要なMod🔴
[Embeddium](https://github.com/embeddedt/embeddium), [Sodium](https://github.com/CaffeineMC/sodium-fabric)([Rubidium](https://github.com/Asek3/Rubidium))

# 更新頻度⌚
気分に応じて更新します。
ただし、何かが未完成の場合、更新することはほとんどありません。

# Modとの互換性👜
Embeddium、Sodium、Rubidium は相互に互換性がありません。いずれかをインストールする場合は、いずれかを使用してください。

# ダウンロードプラットフォーム📁
[CurseForge](https://www.curseforge.com/minecraft/texture-packs/eujt-continued/files/all?page=1&pageSize=20) | [Modrinth(Recommend)](https://modrinth.com/resourcepack/eujt-continued/versions) | [GitHub Releases(Here)](https://github.com/penpea/eujt-continued/releases)

## _私の名前を知っている人がいれば..._ 🐧
もしかしたらこのリソースパックをご存じの方、見覚えがある方もいらっしゃるかもしれません...
はい、このリソースパックは EUJT (Embeddium Translation Resource Pack) の続編です。

更新されていないバージョンは[こちら](https://github.com/penguin06329/Embeddium-Unofficial-Japanese-Translate)です

## その他
[X(Twitter)](https://x.com/penguin06329b)

**Modpackに関して**: 
この翻訳リソース パックをあなたの Modpack に自由に含めることができます。許可など必要ありません。
